### PR TITLE
feat(aanmelding): copy all reported fields

### DIFF
--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -111,20 +111,24 @@ model Project {
 }
 
 model Aanmelding {
-  id                         Int               @id @default(autoincrement())
-  projectId                  Int
-  project                    Project           @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  deelnemerId                Int?
-  deelnemer                  Persoon?          @relation(fields: [deelnemerId], references: [id])
-  deelnames                  Deelname[]
-  woonplaatsDeelnemerId      Int
-  woonplaatsDeelnemer        Plaats            @relation(fields: [woonplaatsDeelnemerId], references: [id])
-  rekeninguittrekselNummer   String?           @db.VarChar(32)
-  opmerking                  String?           @db.VarChar(1024)
-  tijdstipVanAanmelden       DateTime          @default(now())
-  status                     Aanmeldingsstatus @default(Aangemeld)
-  eersteCursusAanmeldingen   Persoon[]         @relation("eersteCursusAanmelding")
-  eersteVakantieAanmeldingen Persoon[]         @relation("eersteVakantieAanmelding")
+  id                       Int               @id @default(autoincrement())
+  projectId                Int
+  project                  Project           @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  deelnemerId              Int?
+  deelnemer                Persoon?          @relation(fields: [deelnemerId], references: [id])
+  deelnames                Deelname[]
+  rekeninguittrekselNummer String?           @db.VarChar(32)
+  tijdstipVanAanmelden     DateTime          @default(now())
+  status                   Aanmeldingsstatus @default(Aangemeld)
+
+  // Fields copied from deelnemer when created
+  plaats                     Plaats?      @relation(fields: [plaatsId], references: [id])
+  plaatsId                   Int?
+  werksituatie               Werksituatie @default(onbekend)
+  woonsituatie               Woonsituatie @default(onbekend)
+  geslacht                   Geslacht     @default(onbekend)
+  eersteCursusAanmeldingen   Persoon[]    @relation("eersteCursusAanmelding")
+  eersteVakantieAanmeldingen Persoon[]    @relation("eersteVakantieAanmelding")
 
   @@unique([projectId, deelnemerId])
   @@map("aanmelding")

--- a/packages/backend/src/organisaties.controller.test.ts
+++ b/packages/backend/src/organisaties.controller.test.ts
@@ -1,6 +1,6 @@
 import { Organisatie } from '@rock-solid/shared';
 import { OrganisatiesController } from './organisaties.controller.js';
-import { factory, harness, onbekendePlaats } from './test-utils.test.js';
+import { factory, harness } from './test-utils.test.js';
 import { expect } from 'chai';
 
 describe(OrganisatiesController.name, () => {
@@ -35,7 +35,7 @@ describe(OrganisatiesController.name, () => {
       const adres = {
         straatnaam: 'Foostraat',
         huisnummer: '1',
-        plaats: onbekendePlaats,
+        plaats: harness.db.seedPlaats,
       };
       const response = await harness
         .post(
@@ -183,7 +183,7 @@ describe(OrganisatiesController.name, () => {
             adres: {
               straatnaam: 'Mousestreet',
               huisnummer: '1',
-              plaats: onbekendePlaats,
+              plaats: harness.db.seedPlaats,
             },
             foldervoorkeuren: [
               {

--- a/packages/backend/src/personen.controller.test.ts
+++ b/packages/backend/src/personen.controller.test.ts
@@ -1,6 +1,6 @@
 import { AanmeldingOf, Cursus, Deelnemer, Vakantie } from '@rock-solid/shared';
 import { PersonenController } from './personen.controller.js';
-import { factory, harness, onbekendePlaats } from './test-utils.test.js';
+import { factory, harness } from './test-utils.test.js';
 import { expect } from 'chai';
 
 describe(PersonenController.name, () => {
@@ -112,7 +112,7 @@ describe(PersonenController.name, () => {
           verblijfadres: {
             straatnaam: 'Kerkstraat',
             huisnummer: '123',
-            plaats: onbekendePlaats,
+            plaats: harness.db.seedPlaats,
           },
         }),
       );

--- a/packages/backend/src/reports.controller.test.ts
+++ b/packages/backend/src/reports.controller.test.ts
@@ -61,6 +61,34 @@ describe(ReportsController.name, () => {
         ];
         expect(report).deep.eq(expectedReport);
       });
+
+      it('should support grouping on "werksituatie" when the deelnemer is deleted', async () => {
+        const { deelnemerA } = await arrangeCursussenTestSet();
+        await harness.deleteDeelnemer(deelnemerA.id);
+        const report = await harness.getReport(
+          'reports/aanmeldingen/aanmeldingen',
+          'werksituatie',
+        );
+        const expectedReport: Report = [
+          { key: 'arbeidszorg', total: 2 },
+          { key: 'onbekend', total: 1 },
+        ];
+        expect(report).deep.eq(expectedReport);
+      });
+
+      it('should support grouping on "woonsituatie" when the deelnemer is deleted', async () => {
+        const { deelnemerA } = await arrangeCursussenTestSet();
+        await harness.deleteDeelnemer(deelnemerA.id);
+        const report = await harness.getReport(
+          'reports/aanmeldingen/aanmeldingen',
+          'woonsituatie',
+        );
+        const expectedReport: Report = [
+          { key: 'residentieleWoonondersteuning', total: 2 },
+          { key: 'onbekend', total: 1 },
+        ];
+        expect(report).deep.eq(expectedReport);
+      });
     });
 
     describe('filter', () => {
@@ -201,7 +229,14 @@ describe(ReportsController.name, () => {
 
   async function arrangeCursussenTestSet() {
     const [deelnemerA, deelnemerB] = await Promise.all([
-      harness.createDeelnemer(factory.deelnemer({ achternaam: 'A' })),
+      harness.createDeelnemer(
+        factory.deelnemer({
+          woonsituatie: 'residentieleWoonondersteuning',
+          werksituatie: 'arbeidszorg',
+          geslacht: 'x',
+          achternaam: 'A',
+        }),
+      ),
       harness.createDeelnemer(factory.deelnemer({ achternaam: 'B' })),
     ]);
     const [projectA, projectB] = await Promise.all([
@@ -242,6 +277,7 @@ describe(ReportsController.name, () => {
       { id: aanmelding2.id, status: 'Aangemeld' },
       { id: aanmelding3.id, status: 'Bevestigd' },
     ]);
+    return { deelnemerA };
   }
   async function arrangeVakantiesTestSet() {
     const [deelnemerC, deelnemerD] = await Promise.all([

--- a/packages/backend/src/seed/adres-seeder.ts
+++ b/packages/backend/src/seed/adres-seeder.ts
@@ -2,7 +2,6 @@ import db from '@prisma/client';
 import { ImportErrors } from './import-errors.js';
 
 const adresRegex = /^(\D+)\s*(\d+)\s?(:?bus)?\s?(.*)?$/;
-const ONBEKENDE_PLAATS_ID = 1; // 1 = "onbekend"
 
 export class AdresSeeder<TRaw> {
   private plaatsIdByPostcode!: Map<string, number>;
@@ -47,13 +46,13 @@ export class AdresSeeder<TRaw> {
     ];
 
     const postCode = postcodeFromRaw(rawPostcode);
-    let plaatsId = this.plaatsIdByPostcode.get(postCode);
+    const plaatsId = this.plaatsIdByPostcode.get(postCode);
     if (plaatsId === undefined) {
       this.importErrors.addWarning('postcode_doesnt_exist', {
         detail: `Cannot find postcode "${postCode}", using onbekend`,
         item: raw,
       });
-      plaatsId = ONBEKENDE_PLAATS_ID;
+      return;
     }
     return {
       create: {

--- a/packages/backend/src/seed/plaatsen.seed.ts
+++ b/packages/backend/src/seed/plaatsen.seed.ts
@@ -17,14 +17,6 @@ export async function seedPlaatsen(client: db.PrismaClient) {
     ),
   ) as RawPlaats[];
 
-  // Plaats 1 is onbekend
-  plaatsen.unshift({
-    deelgemeente: 'Onbekend',
-    gemeente: 'Onbekend',
-    postcode: '0',
-    provincieId: 0,
-    volledigeNaam: 'Onbekend',
-  });
   await client.plaats.createMany({ data: plaatsen });
   console.log(`Seeded ${plaatsen.length} plaatsen`);
 }

--- a/packages/backend/src/services/plaats.mapper.ts
+++ b/packages/backend/src/services/plaats.mapper.ts
@@ -27,5 +27,3 @@ export function toPlaats(p: db.Plaats): Plaats {
   const { provincieId, volledigeNaam, ...props } = p;
   return { ...props, provincie: provincieId };
 }
-
-export const ONBEKENDE_PLAATS_ID = 1;

--- a/packages/backend/src/services/report.mapper.ts
+++ b/packages/backend/src/services/report.mapper.ts
@@ -54,8 +54,8 @@ export class ReportMapper {
       filter.type ? `AND project.type = '${filter.type}'::project_type` : ''
     }
     ${reportTypeJoin(reportType)}
-    INNER JOIN persoon ON persoon.id = aanmelding."deelnemerId"    
-    INNER JOIN plaats ON aanmelding."woonplaatsDeelnemerId" = plaats.id
+    LEFT JOIN persoon ON persoon.id = aanmelding."deelnemerId"    
+    LEFT JOIN plaats ON aanmelding."plaatsId" = plaats.id
     ${filterWhere(filter)}
     GROUP BY ${fieldName(groupField)}${
       secondGroupField ? `, ${fieldName(secondGroupField)}` : ''
@@ -181,11 +181,11 @@ function fieldName(field: AanmeldingGroupField): string {
     case 'provincie':
       return 'plaats."provincieId"';
     case 'woonsituatie':
-      return 'persoon.woonsituatie';
+      return 'aanmelding.woonsituatie';
     case 'werksituatie':
-      return 'persoon.werksituatie';
+      return 'aanmelding.werksituatie';
     case 'geslacht':
-      return 'persoon.geslacht';
+      return 'aanmelding.geslacht';
     case 'organisatieonderdeel':
       return 'project.organisatieonderdeel';
     case 'project':
@@ -200,11 +200,11 @@ function select(field: AanmeldingGroupField): string {
     case 'provincie':
       return '"provincieId"';
     case 'woonsituatie':
-      return 'woonsituatie';
+      return 'aanmelding.woonsituatie';
     case 'werksituatie':
-      return 'werksituatie';
+      return 'aanmelding.werksituatie';
     case 'geslacht':
-      return 'geslacht';
+      return 'aanmelding.geslacht';
     case 'organisatieonderdeel':
       return 'organisatieonderdeel';
     case 'project':

--- a/packages/frontend/src/app/forms/reactive-form-plaats.component.ts
+++ b/packages/frontend/src/app/forms/reactive-form-plaats.component.ts
@@ -85,6 +85,11 @@ export class ReactiveFormPlaats<TEntity> extends FormControlElement<TEntity> {
           id="${this.name}"
           name="${this.control.name}"
           .value="${showPlaats(this.plaatsValue)}"
+          @change=${() => {
+            if (this.inputRef.value!.value === '') {
+              this.plaatsValue = undefined;
+            }
+          }}
           ?required=${this.control.validators?.required}
           placeholder=${ifDefined(this.control.placeholder)}
           @invalid="${this.updateValidationMessage}"

--- a/packages/frontend/src/app/personen/display-persoon.component.ts
+++ b/packages/frontend/src/app/personen/display-persoon.component.ts
@@ -20,6 +20,7 @@ import {
   showAdres,
   showDatum,
   showOverigPersoonSelectie,
+  pluralize,
 } from '../shared';
 import { age, fullName } from './full-name.pipe';
 
@@ -72,7 +73,15 @@ export class DisplayPersoonComponent extends RockElement {
   }
 
   override render() {
-    return html` <h3>Persoonsgegevens</h3>
+    return html` <h3>
+        Persoonsgegevens
+        <rock-link
+          btn
+          btnSecondary
+          href="/${pluralize(this.persoon.type)}/edit/${this.persoon.id}"
+          ><rock-icon icon="pencil"></rock-icon
+        ></rock-link>
+      </h3>
       <div class="row">
         <dl class="col-sm-6">
           <dt>Naam</dt>

--- a/packages/frontend/src/app/personen/full-name.pipe.ts
+++ b/packages/frontend/src/app/personen/full-name.pipe.ts
@@ -1,5 +1,11 @@
 import { Geslacht, UpsertablePersoon } from '@rock-solid/shared';
 
+export function fullNameOrOnbekend(
+  persoon?: Pick<UpsertablePersoon, 'achternaam' | 'voornaam'>,
+) {
+  return persoon ? fullName(persoon) : 'Onbekend';
+}
+
 export function fullName(
   persoon: Pick<UpsertablePersoon, 'achternaam' | 'voornaam'>,
 ) {

--- a/packages/frontend/src/app/projecten/project-aanmelding-edit.component.ts
+++ b/packages/frontend/src/app/projecten/project-aanmelding-edit.component.ts
@@ -1,14 +1,18 @@
 import {
   Aanmelding,
+  aanmeldingLabels,
   aanmeldingsstatussen,
+  geslachten,
   Privilege,
   Project,
+  werksituaties,
+  woonsituaties,
 } from '@rock-solid/shared';
-import { html, LitElement } from 'lit';
+import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { bootstrap } from '../../styles';
-import { InputControl, InputType } from '../forms';
-import { fullName } from '../personen/full-name.pipe';
+import { FormControl, InputType } from '../forms';
+import { fullNameOrOnbekend } from '../personen/full-name.pipe';
 import { printProject } from './project.pipes';
 
 @customElement('rock-project-aanmelding-edit')
@@ -23,15 +27,44 @@ export class ProjectAanmeldingEditComponent extends LitElement {
 
   public override render() {
     return html`<h2>
-        Aanmelding van ${fullName(this.aanmelding.deelnemer!)} voor
+        Aanmelding van ${fullNameOrOnbekend(this.aanmelding.deelnemer)} voor
         ${printProject(this.project)}
       </h2>
+      ${this.aanmelding.deelnemer
+        ? html`<div class="row mb-3">
+            <div class="col-lg-2 col-md-4"></div>
+            <div class="col">
+              <button
+                @click=${() => this.copyDeelnemerFields()}
+                class="btn btn-outline-primary"
+              >
+                <rock-icon icon="clipboardCheck"></rock-icon>
+                Kopieer velden deelnemer
+              </button>
+            </div>
+          </div>`
+        : nothing}
+
       <rock-reactive-form
         @rock-submit="${this.save}"
         privilege="${'write:aanmeldingen' satisfies Privilege}"
-        .controls="${aanmeldingControls}"
-        .entity="${this.aanmelding}"
+        .controls=${aanmeldingControls}
+        .entity=${this.aanmelding}
       ></rock-reactive-form>`;
+  }
+
+  private copyDeelnemerFields() {
+    if (this.aanmelding.deelnemer) {
+      const { deelnemer } = this.aanmelding;
+      this.aanmelding.plaats =
+        deelnemer.domicilieadres?.plaats ?? deelnemer.verblijfadres?.plaats;
+      this.aanmelding.woonsituatie = deelnemer.woonsituatie;
+      this.aanmelding.werksituatie = deelnemer.werksituatie;
+      this.aanmelding.geslacht = deelnemer.geslacht;
+      this.aanmelding = {
+        ...this.aanmelding,
+      };
+    }
   }
 
   private async save() {
@@ -44,13 +77,36 @@ export class ProjectAanmeldingEditComponent extends LitElement {
   }
 }
 
-const aanmeldingControls: InputControl<Aanmelding>[] = [
+const aanmeldingControls: FormControl<Aanmelding>[] = [
   {
     name: 'status',
-    label: 'Status',
+    label: aanmeldingLabels.status,
     type: InputType.select,
     grouped: false,
     items: aanmeldingsstatussen,
+  },
+  {
+    name: 'plaats',
+    label: aanmeldingLabels.plaats,
+    type: InputType.plaats,
+  },
+  {
+    name: 'woonsituatie',
+    label: aanmeldingLabels.woonsituatie,
+    type: InputType.radio,
+    items: woonsituaties,
+  },
+  {
+    name: 'werksituatie',
+    label: aanmeldingLabels.werksituatie,
+    type: InputType.radio,
+    items: werksituaties,
+  },
+  {
+    name: 'geslacht',
+    label: aanmeldingLabels.geslacht,
+    type: InputType.radio,
+    items: geslachten,
   },
   {
     name: 'rekeninguittrekselNummer',

--- a/packages/frontend/src/app/projecten/project.pipes.ts
+++ b/packages/frontend/src/app/projecten/project.pipes.ts
@@ -5,6 +5,7 @@ export function printProject(project: UpsertableProject) {
   return `${project.projectnummer}: ${project.naam}`;
 }
 
-export const deelnemerVerwijderd = html`<span title="Deelnemer is verwijderd"
-  >❓</span
->`;
+export const deelnemerVerwijderd = html`<rock-icon
+  title="Deelnemer is verwijderd"
+  icon="questionCircle"
+></rock-icon>`;

--- a/packages/frontend/src/app/shared/icon.component.ts
+++ b/packages/frontend/src/app/shared/icon.component.ts
@@ -10,7 +10,7 @@ export class IconComponent extends LitElement {
   public icon!: keyof typeof icons;
 
   @property()
-  public size: 'sm' | 'md' | 'lg' = 'md';
+  public size: 'sm' | 'md' | 'lg' | 'xl' = 'md';
 
   static override styles = [
     bootstrap,
@@ -27,6 +27,11 @@ export class IconComponent extends LitElement {
       }
       .icon-lg svg,
       .icon-lg img {
+        width: 24px;
+        height: 24px;
+      }
+      .icon-xl svg,
+      .icon-xl img {
         width: 32px;
         height: 32px;
       }

--- a/packages/frontend/src/app/shared/icons.ts
+++ b/packages/frontend/src/app/shared/icons.ts
@@ -19,6 +19,22 @@ export const icons = {
   <path d="M8 7a.5.5 0 0 1 .5.5V9H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V10H6a.5.5 0 0 1 0-1h1.5V7.5A.5.5 0 0 1 8 7z"/>
   <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
 </svg>`,
+  checkCircle: svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-circle" viewBox="0 0 16 16">
+  <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+  <path d="M10.97 4.97a.235.235 0 0 0-.02.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-1.071-1.05z"/>
+</svg>`,
+  clipboardCheck: svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clipboard-check" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M10.854 7.146a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0l-1.5-1.5a.5.5 0 1 1 .708-.708L7.5 9.793l2.646-2.647a.5.5 0 0 1 .708 0z"/>
+  <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1v-1z"/>
+  <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h3zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3z"/>
+</svg>`,
+  exclamationCircle: svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-circle" viewBox="0 0 16 16">
+  <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+  <path d="M7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995z"/>
+</svg>`,
+  exclamationTriangleFill: svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-triangle-fill" viewBox="0 0 16 16">
+  <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+</svg>`,
   journalPlus: svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-journal-plus" viewBox="0 0 16 16">
 <path fill-rule="evenodd" d="M8 5.5a.5.5 0 0 1 .5.5v1.5H10a.5.5 0 0 1 0 1H8.5V10a.5.5 0 0 1-1 0V8.5H6a.5.5 0 0 1 0-1h1.5V6a.5.5 0 0 1 .5-.5z"/>
 <path d="M3 0h10a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2v-1h1v1a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v1H1V2a2 2 0 0 1 2-2z"/>
@@ -68,6 +84,9 @@ export const icons = {
   unlock: svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-unlock" viewBox="0 0 16 16">
   <path d="M11 1a2 2 0 0 0-2 2v4a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h5V3a3 3 0 0 1 6 0v4a.5.5 0 0 1-1 0V3a2 2 0 0 0-2-2zM3 8a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1H3z"/>
 </svg>`,
+  lock: svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-lock" viewBox="0 0 16 16">
+  <path d="M8 1a2 2 0 0 1 2 2v4H6V3a2 2 0 0 1 2-2zm3 6V3a3 3 0 0 0-6 0v4a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2zM5 8h6a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1z"/>
+</svg>`,
   trash: svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
 <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
 <path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
@@ -92,6 +111,13 @@ export const icons = {
 </svg>`,
   genderTrans: svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-gender-trans" viewBox="0 0 16 16">
 <path fill-rule="evenodd" d="M0 .5A.5.5 0 0 1 .5 0h3a.5.5 0 0 1 0 1H1.707L3.5 2.793l.646-.647a.5.5 0 1 1 .708.708l-.647.646.822.822A3.99 3.99 0 0 1 8 3c1.18 0 2.239.51 2.971 1.322L14.293 1H11.5a.5.5 0 0 1 0-1h4a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-1 0V1.707l-3.45 3.45A4 4 0 0 1 8.5 10.97V13H10a.5.5 0 0 1 0 1H8.5v1.5a.5.5 0 0 1-1 0V14H6a.5.5 0 0 1 0-1h1.5v-2.03a4 4 0 0 1-3.05-5.814l-.95-.949-.646.647a.5.5 0 1 1-.708-.708l.647-.646L1 1.707V3.5a.5.5 0 0 1-1 0v-3zm5.49 4.856a3 3 0 1 0 5.02 3.288 3 3 0 0 0-5.02-3.288z"/>
+</svg>`,
+  genderNeuter: svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-gender-neuter" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M8 1a4 4 0 1 0 0 8 4 4 0 0 0 0-8ZM3 5a5 5 0 1 1 5.5 4.975V15.5a.5.5 0 0 1-1 0V9.975A5 5 0 0 1 3 5Z"/>
+</svg>`,
+  questionCircle: svg`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle" viewBox="0 0 16 16">
+  <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+  <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z"/>
 </svg>`,
   customVegetarian: html`<img
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAA3QAAAN0BcFOiBwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAQGSURBVFiFvZZZaFxlFMd/57szk07amErrQotgHwQfCiIUTZqJNQ8GG5N2EmypC0YUWgQD6SKKCFXwQUNtbCtiXfrigqSS1bRqhbFJnSZl4oNSXF4rtqXpkiaZTOYux4dJJsOQaWZGk+9lvu+cc///3z33Xs6IqlLZXt0ncLeLvjS8+0yMRVp1J+tKTGLZ22K8es8zW/sbO/8yAAglChsMMlTZHmpeDPOG7sZHremSsyK6D5X7LeNtATAA42PX60XlQOosxza2Vz/9f5gKIg094YaG7sYoEAEeTCdV7gMQVU3HNh4M7VKRjwBXRXYMtQ58U4zx9uPbrSmfswPR14D1Ocp+6gt31ZjMSHTPmaMobYAlql9Vtlc3FGq+pbtxc8Jv/4noF7cwn78DkGpbRXvoa2A7MKY+3/qhlsjfCxk3dTWtSooeEXgqT9arfeGu1SY7qqguu+lrBn4GysVxPslHzRb9tABzAAdmXsLsFdkfSdieLwyMAo9vfL/6hVspbelqqgfCBZgD2DkBAGJ7I6OovA6gKm2htlBZTinRN7JDqsrYxTFuXr6Z66rLtwQAGBof/Az4BXSVE6A1V53CvdmxydFJ7ISN53o5mOX7BQF0v3qipgVQUdlb/U717dk1Gz7e5QfuzIwlxhMkJhKIEcrumL9xnvH6FwQAiO45HQX6gXKnRPdl59esuegH0rfpJB0mr04CULa6DMtvzSd7pTQZGM4LAADh0MympebDmhWZqd763jjw6+x54soEqkqwPEhgeWA+NUfg2Y5tHW7eAGdbB38UOA+UJRLuk/OU9AMk40mcpIOxDKUrS+e/F9GXe8NdP8ye8+sA4AmHUwr6fHbOtf2Hgan49TgAwZVBxEh22biqvNi7tftoZjBvAKPu58A14JGHD2xal5k7sa3jytRYvN9JOlg+i2BZMDM9JcJxsdwHvm3sPJat68sXILo7OlV5MPQlIi3GeM3Am5n5yWvxewCMZX0Acl5Rz8CFZbZ/sGNbx0Qu3bwBAATTo2gLwnOZABWHKu4S/A8BmnS9d/saOxecHbMr70cAkFwRH1C4AayrOlyVnnTiBjYDoshQPoOraIDYzpiNchLAc0ztnIrWAQgcL0SvYICUifbMbB4DqHmrxodSC6irUvAfmIIBbDv4HalJtqnuSF3J9G1uFVAODJ/bc/rCogPEXj01BpwGgjfsiZBqqv1o4e0vCgBAkMGUp9aK8ASAiDlVjFZBn+HscoURo4DwjMJawE4un/yjGK2iOqC2NTKzXTvz+3tsZ8xeMoBzr0QuIfwzRyS/FaNTNEDKlJH03syN46UDkAwAvKXvgHhzAMZowd//fwZIGkkDTNuBS0sOEGsduAi8B0RieyOjxer8CzLDgO7xrO8oAAAAAElFTkSuQmCC"

--- a/packages/shared/src/aanmelding.ts
+++ b/packages/shared/src/aanmelding.ts
@@ -1,5 +1,6 @@
+import { Plaats } from './adres.js';
 import { Options } from './options.js';
-import { Deelnemer } from './persoon.js';
+import { Deelnemer, Geslacht, Werksituatie, Woonsituatie } from './persoon.js';
 import { Upsertable } from './upsertable.js';
 
 export interface Aanmelding {
@@ -10,6 +11,11 @@ export interface Aanmelding {
   rekeninguittrekselNummer?: string;
   opmerking?: string;
   deelnemer?: Deelnemer;
+  werksituatie: Werksituatie;
+  woonsituatie: Woonsituatie;
+  geslacht: Geslacht;
+  plaats?: Plaats;
+
   status: Aanmeldingsstatus;
 }
 
@@ -45,5 +51,9 @@ export const aanmeldingLabels: Record<keyof Aanmelding, string> = {
   rekeninguittrekselNummer: 'Rekeninguittreksel nummer',
   opmerking: 'Opmerking',
   deelnemer: 'Deelnemer',
+  plaats: 'Plaats',
+  werksituatie: 'Werksituatie',
+  woonsituatie: 'Woonsituatie',
+  geslacht: 'Geslacht',
   status: 'Status',
 };


### PR DESCRIPTION
Copy all fields that we want to report on to aanmelding when we create it.

- Add the fields on the edit-aanmelding form
- Add a button to copy over the deelnemer fields
- Make plaats of aanmelding nullable (instead of magic onbekend plaats)
- Add a clear warning message
- Update reporting to use the new fields
- Clearup the aanmeldingen screen in general

Fixes #113