### PR TITLE
feat(organisatie): empty contact for new organisatie

### DIFF
--- a/packages/frontend/src/app/organisaties/edit-organisatie.component.ts
+++ b/packages/frontend/src/app/organisaties/edit-organisatie.component.ts
@@ -94,6 +94,6 @@ const organisatieControls: FormControl<Organisatie>[] = [
         requiredLabel: 'Met adres',
       }),
     ],
-    () => ({ terAttentieVan: '' }),
+    () => ({ terAttentieVan: '', foldervoorkeuren: [{}] }),
   ),
 ];

--- a/packages/frontend/src/app/organisaties/organisaties.component.ts
+++ b/packages/frontend/src/app/organisaties/organisaties.component.ts
@@ -178,5 +178,5 @@ export class OrganisatiesComponent extends RockElement {
 }
 
 function newOrganisatie(): DeepPartial<Organisatie> {
-  return { contacten: [] };
+  return { contacten: [{ foldervoorkeuren: [{}] }] };
 }


### PR DESCRIPTION
- Automatically add an empty contact in the new organization form.
- Automatically add a new foldervoorkeur for a new contact in the edit organization form.

Fixes #129
