### PR TITLE
feat(activiteit): set default start time to 18:30.

### DIFF
--- a/packages/frontend/src/app/projecten/project-edit.component.ts
+++ b/packages/frontend/src/app/projecten/project-edit.component.ts
@@ -205,8 +205,8 @@ export function newActiviteit(): DeepPartial<CursusActiviteit> {
   const offsetTillNextFriday = (van.getDay() + 5) % 7 || 7;
   van.setDate(van.getDate() + offsetTillNextFriday);
   totEnMet.setDate(van.getDate() + 3);
-  van.setHours(20);
-  van.setMinutes(0);
+  van.setHours(18);
+  van.setMinutes(30);
   totEnMet.setHours(16);
   totEnMet.setMinutes(0);
   return { van, totEnMet, vormingsuren: 19 };


### PR DESCRIPTION
During testing we discovered that 18:30 (instead of 20:00) is the better default.
