### PR TITLE
feat(projecten): aantal inschrijvingen zonder annulaties en wachtrij

### DIFF
--- a/packages/backend/src/personen.controller.test.ts
+++ b/packages/backend/src/personen.controller.test.ts
@@ -101,7 +101,7 @@ describe(PersonenController.name, () => {
         { ...cursus2, aantalAanmeldingen: 2, status: 'Aangemeld' },
       ];
       const expectedVakantieAanmeldingen: AanmeldingOf<Vakantie>[] = [
-        { ...vakantie1, aantalAanmeldingen: 1, status: 'Geannuleerd' },
+        { ...vakantie1, aantalAanmeldingen: 0, status: 'Geannuleerd' },
       ];
       expect(actualCursussen.sort(byId)).deep.eq(
         expectedCursusAanmeldingen.sort(byId),

--- a/packages/backend/src/services/project.mapper.ts
+++ b/packages/backend/src/services/project.mapper.ts
@@ -60,7 +60,16 @@ const includeAggregate = {
   },
   _count: {
     select: {
-      aanmeldingen: true,
+      aanmeldingen: {
+        where: {
+          status: {
+            in: [
+              aanmeldingsstatusMapper.toDB('Aangemeld'),
+              aanmeldingsstatusMapper.toDB('Bevestigd'),
+            ],
+          },
+        },
+      },
     },
   },
 } as const satisfies Prisma.ProjectInclude;

--- a/packages/backend/src/test-utils.test.ts
+++ b/packages/backend/src/test-utils.test.ts
@@ -394,9 +394,9 @@ class IntegrationTestingHarness {
   async patchAanmelding(
     projectId: number,
     aanmelding: PatchableAanmelding,
-  ): Promise<Aanmelding[]> {
+  ): Promise<Aanmelding> {
     const response = await this.patch(
-      `/projecten/${projectId}/aanmeldingen/${aanmelding.id}}`,
+      `/projecten/${projectId}/aanmeldingen/${aanmelding.id}`,
       aanmelding,
     ).expect(200);
     return response.body;


### PR DESCRIPTION
Laadt in het knopje om het aanmeldingsscherm te openen enkel nog een getal zien van het aantal bevestigde en aangemelde aanmeldingen (niet meer wachtrij of geannuleerd).

Closes #204