### PR TITLE
fix(deelnames): verwijder deelnames bij annuleren of naar wachtrij

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "🧪 Run Backend Tests",
-      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/mocha.js",
       "args": [
         "--timeout",
         "0",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -146,4 +146,5 @@
   ],
   "cSpell.ignoreWords": ["transform", "bootstrap", "hour"],
   "cSpell.language": "en,nl",
+  "typescript.tsdk": "node_modules/typescript/lib",
 }

--- a/packages/backend/src/personen.controller.test.ts
+++ b/packages/backend/src/personen.controller.test.ts
@@ -99,7 +99,12 @@ describe(PersonenController.name, () => {
 
       // Assert
       const expectedCursusAanmeldingen: AanmeldingOf<Cursus>[] = [
-        { ...cursus1, aantalInschrijvingen: 1, status: 'Bevestigd' },
+        {
+          ...cursus1,
+          activiteiten: [{ ...cursus1.activiteiten[0]!, isCompleted: false }],
+          aantalInschrijvingen: 1,
+          status: 'Bevestigd',
+        },
         { ...cursus2, aantalInschrijvingen: 2, status: 'Aangemeld' },
       ];
       const expectedVakantieAanmeldingen: AanmeldingOf<Vakantie>[] = [

--- a/packages/shared/src/aanmelding.ts
+++ b/packages/shared/src/aanmelding.ts
@@ -35,6 +35,12 @@ export const aanmeldingsstatussen: Options<Aanmeldingsstatus> = {
   OpWachtlijst: 'Op wachtlijst',
 };
 
+export const aanmeldingsstatussenWithoutDeelnames = [
+  'Geannuleerd',
+  'OpWachtlijst',
+  'Aangemeld',
+] as Aanmeldingsstatus[];
+
 export function isAanmeldingsstatus(maybe: string): maybe is Aanmeldingsstatus {
   return maybe in aanmeldingsstatussen;
 }
@@ -44,7 +50,7 @@ export type InsertableAanmelding = Upsertable<
   'deelnemerId' | 'projectId'
 >;
 
-export type UpdatableAanmelding = Upsertable<Aanmelding, 'id'> & {
+export type UpdatableAanmelding = Upsertable<Aanmelding, 'id' | 'status'> & {
   overrideDeelnemerFields?: boolean;
 };
 


### PR DESCRIPTION
- Verwijder de deelnames van een aanmelding wanneer je deze van "bevestigd" naar de wachtrij verplaatst, annuleert of veranderd naar "aangemeld".
  - Hierdoor worden activiteiten
- Ook aangepast: een activiteit van een project die in het verleden ligt en waarvoor geen aanmeldingen zijn wordt nu gezien als afgerond.

Closes #236