### PR TITLE
fix(plaats): Brussel tonen als 'Brussel' in plaats van onbekend

### DIFF
--- a/packages/backend/src/services/plaats.mapper.ts
+++ b/packages/backend/src/services/plaats.mapper.ts
@@ -16,7 +16,6 @@ export class PlaatsMapper {
     const plaatsen = await this.db.plaats.findMany({
       where: {
         volledigeNaam: { contains: filter.search },
-        id: { gt: 1 }, // Plaats 1 is "onbekend"
       },
       orderBy: [{ volledigeNaam: 'asc' }],
     });

--- a/packages/frontend/src/app/shared/autocomplete.component.ts
+++ b/packages/frontend/src/app/shared/autocomplete.component.ts
@@ -194,7 +194,9 @@ export class AutocompleteComponent extends LitElement {
           ),
           tap(() => (this.isLoading = false)),
         )
-        .subscribe((hints) => (this.hints = hints)),
+        .subscribe((hints) => {
+          this.hints = hints;
+        }),
     );
   }
 

--- a/packages/frontend/src/app/shared/utility.pipes.ts
+++ b/packages/frontend/src/app/shared/utility.pipes.ts
@@ -118,9 +118,6 @@ export function showDatumWithAge(val?: Date): string {
 
 export function showPlaats(plaats?: Plaats): string {
   if (plaats) {
-    if (plaats.id === 1) {
-      return unknown;
-    }
     return `${plaats.postcode} ${plaats.deelgemeente} (${plaats.gemeente})`;
   } else {
     return '';


### PR DESCRIPTION
Brussel werd getoond als onbekend doordat een oude oplossing voor onbekende adressen nog niet volledig was verwijderd uit de code. Dit is nu opgelost, Brussel is teruggezet voor deze personen en plaatsen.
